### PR TITLE
Bump version: 0.0.4 → 0.0.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5
 commit = True
 tag = True
 push = True

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluxon version 0.0.4""
+# Fluxon version 0.0.5"""
 
 **Pronunciation**: *Fluhk-sawn*
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fluxon",
-    version="0.0.4",
+    version="0.0.5",
     description="A Python library for crafting structured prompts and parsing structured outputs with a focus on JSON.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request includes updates to increment the version number of the Fluxon library from 0.0.4 to 0.0.5.

Version updates:

* [`.bumpversion.cfg`](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2): Updated `current_version` to 0.0.5.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated version number in the documentation to 0.0.5.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated `version` to 0.0.5.