### PR TITLE
Bump version v0.0.7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6
+current_version = 0.0.7
 commit = True
 tag = True
 push = True

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fluxon v0.0.6
+# Fluxon v0.0.7
 
 **Pronunciation**: *Fluhk-sawn*
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fluxon",
-    version="0.0.6",
+    version="0.0.7",
     description="A Python library for crafting structured prompts and parsing structured outputs with a focus on JSON.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/src/fluxon/parser.py
+++ b/src/fluxon/parser.py
@@ -103,7 +103,23 @@ def add_missing_commas_in_arrays(json_str: str) -> str:
     
     return fixed_json
 
+def add_missing_brackets(json_str: str) -> str:
+    """
+    Adds missing brackets to JSON strings. This function assumes that the JSON string is a dictionary.
 
+    Args:
+        json_str (str): The JSON string with potential missing brackets.
+
+    Returns:
+        str: A JSON string with added brackets.
+    """
+
+    if not json_str.strip().startswith("{"):
+        json_str = "{" + json_str
+    if not json_str.strip().endswith("}"):
+        json_str = json_str + "}"
+    return json_str
+    
 
 def fix_common_json_errors(json_str: str) -> str:
     """
@@ -130,6 +146,8 @@ def fix_common_json_errors(json_str: str) -> str:
         r'\1 "\2":', 
         json_str
     )
+    
+    json_str = add_missing_brackets(json_str)
 
     return json_str
 


### PR DESCRIPTION
This pull request includes a version update and a new function to handle JSON parsing in the `fluxon` library. The most important changes include updating the version number across various files and adding a function to ensure JSON strings have the correct brackets.

Version update:

* [`.bumpversion.cfg`](diffhunk://#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fL2-R2): Updated `current_version` from `0.0.6` to `0.0.7`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated version number in the title from `0.0.6` to `0.0.7`.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated `version` from `0.0.6` to `0.0.7`.

JSON parsing improvements:

* [`src/fluxon/parser.py`](diffhunk://#diff-79a9e5d919a4c6dc672e9d9be93abfe81932fb44ba19056628aa43403856e889R106-R121): Added a new function `add_missing_brackets` to ensure JSON strings have the correct brackets.
* [`src/fluxon/parser.py`](diffhunk://#diff-79a9e5d919a4c6dc672e9d9be93abfe81932fb44ba19056628aa43403856e889R150-R151): Updated `fix_common_json_errors` to call `add_missing_brackets` to handle missing brackets in JSON strings.