### PR TITLE
feat: Add methods to get json objects

### DIFF
--- a/src/fluxon/structured_parsing/content_tokenizer.py
+++ b/src/fluxon/structured_parsing/content_tokenizer.py
@@ -1,5 +1,17 @@
 import re
+from enum import Enum
 from fluxon.structured_parsing.exceptions import UnRecognizedInputFormatError, MalformedJsonError
+
+
+
+class CommentedJsonPartTypes(Enum):
+    FREE_TEXT = "free_text"
+    JSON_OBJECT = "json_object"
+
+class CommentedJsonPart:
+    def __init__(self, part_type: CommentedJsonPartTypes, value: str):
+        self.part_type = part_type
+        self.value = value
 
 
 class ContentTokenizer:
@@ -56,7 +68,7 @@ class ContentTokenizer:
             if input_text.startswith('{'):
                 json_object, input_text = self.extract_nested_json(input_text)
                 if json_object:
-                    self.tokens.append({"type": "json_object", "value": json_object})
+                    self.tokens.append({"type": CommentedJsonPartTypes.JSON_OBJECT, "value": json_object})
                 else:
                     raise MalformedJsonError("Malformed JSON detected")
 
@@ -64,7 +76,7 @@ class ContentTokenizer:
             else:
                 match = re.match(self.TOKEN_PATTERNS["free_text"], input_text)
                 if match:
-                    self.tokens.append({"type": "free_text", "value": match.group(0).strip()})
+                    self.tokens.append({"type": CommentedJsonPartTypes.FREE_TEXT, "value": match.group(0).strip()})
                     input_text = input_text[match.end():]
                 else:
                     raise UnRecognizedInputFormatError(f"Unrecognized input: {input_text[:30]}")

--- a/tests/test_structured_parsing/test_content_tokenizer.py
+++ b/tests/test_structured_parsing/test_content_tokenizer.py
@@ -1,5 +1,5 @@
 import unittest
-from fluxon.structured_parsing.content_tokenizer import ContentTokenizer
+from fluxon.structured_parsing.content_tokenizer import ContentTokenizer, CommentedJsonPartTypes
 from fluxon.structured_parsing.exceptions import MalformedJsonError
 
 
@@ -11,22 +11,22 @@ class TestContentTokenizer(unittest.TestCase):
         input_text = "This is some free text."
         tokens = self.tokenizer.tokenize(input_text)
         self.assertEqual(len(tokens), 1)
-        self.assertEqual(tokens[0]["type"], "free_text")
+        self.assertEqual(tokens[0]["type"], CommentedJsonPartTypes.FREE_TEXT)
         self.assertEqual(tokens[0]["value"], "This is some free text.")
 
     def test_json_object(self):
         input_text = '{"key1": "value1"}'
         tokens = self.tokenizer.tokenize(input_text)
         self.assertEqual(len(tokens), 1)
-        self.assertEqual(tokens[0]["type"], "json_object")
+        self.assertEqual(tokens[0]["type"], CommentedJsonPartTypes.JSON_OBJECT)
 
     def test_mixed_content(self):
         input_text = "Text before JSON. {\"key1\": \"value1\"} Text after JSON."
         tokens = self.tokenizer.tokenize(input_text)
         self.assertEqual(len(tokens), 3)
-        self.assertEqual(tokens[0]["type"], "free_text")
-        self.assertEqual(tokens[1]["type"], "json_object")
-        self.assertEqual(tokens[2]["type"], "free_text")
+        self.assertEqual(tokens[0]["type"], CommentedJsonPartTypes.FREE_TEXT)
+        self.assertEqual(tokens[1]["type"], CommentedJsonPartTypes.JSON_OBJECT)
+        self.assertEqual(tokens[2]["type"], CommentedJsonPartTypes.FREE_TEXT)
 
     def test_malformed_json(self):
         input_text = "{This is not valid JSON"

--- a/tests/test_structured_parsing/test_structured_parser.py
+++ b/tests/test_structured_parsing/test_structured_parser.py
@@ -1,5 +1,6 @@
 import unittest
 from fluxon.structured_parsing.fluxon_structured_parser import FluxonStructuredParser
+from fluxon.structured_parsing.content_tokenizer import CommentedJsonPartTypes
 from fluxon.utils import normalize_json
 
 
@@ -11,23 +12,23 @@ class TestFluxonStructuredParser(unittest.TestCase):
         input_text = "This is just some free text."
         result = self.parser.parse(input_text)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["type"], "free_text")
+        self.assertEqual(result[0]["type"], CommentedJsonPartTypes.FREE_TEXT)
         self.assertEqual(result[0]["value"], "This is just some free text.")
 
     def test_json_object_only(self):
         input_text = '{"key1": "value1"}'
         result = self.parser.parse(input_text)
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["type"], "json_object")
+        self.assertEqual(result[0]["type"], CommentedJsonPartTypes.JSON_OBJECT)
         self.assertEqual(len(result[0]["value"]), 1)
 
     def test_mixed_content(self):
         input_text = "Text before JSON. {\"key1\": \"value1\"} Text after JSON."
         result = self.parser.parse(input_text)
         self.assertEqual(len(result), 3)
-        self.assertEqual(result[0]["type"], "free_text")
-        self.assertEqual(result[1]["type"], "json_object")
-        self.assertEqual(result[2]["type"], "free_text")
+        self.assertEqual(result[0]["type"], CommentedJsonPartTypes.FREE_TEXT)
+        self.assertEqual(result[1]["type"], CommentedJsonPartTypes.JSON_OBJECT)
+        self.assertEqual(result[2]["type"], CommentedJsonPartTypes.FREE_TEXT)
 
     def test_render_pretty(self):
         input_text = '{"key1": "value1", "key2": {"nestedKey": "nestedValue"}}'


### PR DESCRIPTION
This pull request introduces significant changes to the structured parsing functionality by adding new classes and refactoring existing code to use enums for better type safety and readability. The main changes include the creation of `CommentedJsonPartTypes` and `CommentedJsonPart` classes, refactoring of the `ContentTokenizer` and `FluxonStructuredParser` classes to use these new classes, and updates to the test cases to reflect these changes.

### Introduction of new classes:
* [`src/fluxon/structured_parsing/content_tokenizer.py`](diffhunk://#diff-ddf0690aea8a8faa72a25b0bfdb84931cbeaa40ee8201230496c116726db9784R2-R16): Added `CommentedJsonPartTypes` enum and `CommentedJsonPart` class to represent the types of parts in commented JSON and their values.

### Refactoring to use new classes:
* [`src/fluxon/structured_parsing/content_tokenizer.py`](diffhunk://#diff-ddf0690aea8a8faa72a25b0bfdb84931cbeaa40ee8201230496c116726db9784L59-R79): Updated the `tokenize` method in `ContentTokenizer` to use `CommentedJsonPartTypes` instead of string literals for token types.
* [`src/fluxon/structured_parsing/fluxon_structured_parser.py`](diffhunk://#diff-cddbe5bcdea7255522aaed26d06c859fc960d8371d5933c11d8584537de4aee9R1-R6): Modified the `parse` and `render` methods in `FluxonStructuredParser` to use `CommentedJsonPartTypes` for token types. Added new methods `get_json_objects` and `get_sorted_json_objects` to extract and sort JSON objects from parsed output. [[1]](diffhunk://#diff-cddbe5bcdea7255522aaed26d06c859fc960d8371d5933c11d8584537de4aee9R1-R6) [[2]](diffhunk://#diff-cddbe5bcdea7255522aaed26d06c859fc960d8371d5933c11d8584537de4aee9L23-R33) [[3]](diffhunk://#diff-cddbe5bcdea7255522aaed26d06c859fc960d8371d5933c11d8584537de4aee9L45-R85)

### Test case updates:
* [`tests/test_structured_parsing/test_content_tokenizer.py`](diffhunk://#diff-b222c7fd04b3567606809a489c7302a201cffa24a067ef1b62c6fba17ee25838L2-R2): Updated test cases to use `CommentedJsonPartTypes` for token type assertions. [[1]](diffhunk://#diff-b222c7fd04b3567606809a489c7302a201cffa24a067ef1b62c6fba17ee25838L2-R2) [[2]](diffhunk://#diff-b222c7fd04b3567606809a489c7302a201cffa24a067ef1b62c6fba17ee25838L14-R29)
* [`tests/test_structured_parsing/test_structured_parser.py`](diffhunk://#diff-26fdb5cf168a2e54f90199a3d3de346067f13bd31853edf2614ae450957040f6R3): Updated test cases to use `CommentedJsonPartTypes` for token type assertions. [[1]](diffhunk://#diff-26fdb5cf168a2e54f90199a3d3de346067f13bd31853edf2614ae450957040f6R3) [[2]](diffhunk://#diff-26fdb5cf168a2e54f90199a3d3de346067f13bd31853edf2614ae450957040f6L14-R31)